### PR TITLE
Restrict build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,12 @@ description: |
 grade: devel
 confinement: strict
 
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
 environment:
   LOUNGE_HOME: $SNAP_DATA/home
 


### PR DESCRIPTION
thelounge isn't supported on some of our more weird arches.