### PR TITLE
Add certbot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,31 @@ apps:
     plugs:
     - network
     - network-bind
+  cert-generate:
+    command: certbot certonly --standalone --logs-dir $SNAP_COMMON/letsencrypt/log --config-dir $SNAP_COMMON/letsencrypt/ --work-dir $SNAP_COMMON/letsencrypt/ --no-eff-email
+    environment:
+      AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
+    plugs:
+      - network
+      - network-bind
+  cert-renew:
+    command: certbot -q renew --logs-dir $SNAP_COMMON/letsencrypt/log --config-dir $SNAP_COMMON/letsencrypt/ --work-dir $SNAP_COMMON/letsencrypt/ --no-eff-email
+    daemon: oneshot
+    environment:
+      AUGEAS_LENS_LIB: $SNAP/usr/share/augeas/lenses/dist
+    plugs:
+      - network
+      - network-bind
+    passthrough:
+        # Run approximately twice a day with randomization
+        timer: 00:00~24:00/2
+  cert-renew-manual:
+    command: certbot -q renew --logs-dir $SNAP_COMMON/letsencrypt/log --config-dir $SNAP_COMMON/letsencrypt/ --work-dir $SNAP_COMMON/letsencrypt/ --no-eff-email
+    environment:
+      AUGEAS_LENS_LIB: $SNAP/usr/share/augeas/lenses/dist
+    plugs:
+      - network
+      - network-bind
 
 parts:
   thelounge:
@@ -74,6 +99,8 @@ parts:
     build-packages:
     - build-essential
     - python
+    stage-snaps:
+      - certbot/latest/edge
     prime:
     - -**/.*.swp # Exclude rogue vim swap files from node-tar package
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,11 +8,48 @@ description: |
  * **Responsive interface.** The client works smoothly on every desktop, smartphone and tablet.
  * **Synchronized experience.** Always resume where you left off no matter what device.
 
+ ## Default port
+
+ By default thelounge listens on TCP port 9000.
+
+ ## Create users
+
  After installing run the following in a terminal/console:
 
  `sudo thelounge add $USER`
 
  Replace `$USER` with your preferred Lounge username. You will be prompted to add a password once you've authenticated for sudo. When you have added your username navigate to http://localhost:9000/ (replace localhost with your server IP or hostname if you are on a different machine) and login with your new username and password.
+
+ ## Enable https
+
+ **For this to work, port 80 on your device must be Internet accessible.**
+
+ Run the following in a terminal/console:
+
+ `sudo thelounge.cert-generate`
+
+ Enter your email address, agree to the terms of service and enter your
+ domain when prompted.
+
+ Update the `https` stanza in thelounge configuration, replacing `example.org` with your domain.
+
+ `sudo nano /var/snap/thelounge/current/home/config.js`
+
+ The `https` stanza should look something like this:
+
+ ```
+ https: {
+        enable: true,
+        key: "/var/snap/thelounge/common/letsencrypt/live/example.org/privkey.pem",
+        certificate: "/var/snap/thelounge/common/letsencrypt/live/example.org/fullchain.pem",
+        ca: "",
+ },
+ ```
+
+ Restart thelounge to enable https.
+
+ `sudo snap restart thelounge`
+ 
 
 base: core18
 grade: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,6 +106,14 @@ apps:
       - network-bind
 
 parts:
+  certbot:
+    plugin: python
+    python-packages: [certbot]
+    build-packages:
+      - libffi-dev
+      - libcurl4-openssl-dev
+      - libssl-dev
+      - python3-dev
   thelounge:
     source: https://github.com/thelounge/thelounge.git
     plugin: nodejs
@@ -136,8 +144,8 @@ parts:
     build-packages:
     - build-essential
     - python
-    stage-snaps:
-      - certbot/latest/edge
+#    stage-snaps:
+#      - certbot/latest/edge
     prime:
     - -**/.*.swp # Exclude rogue vim swap files from node-tar package
 


### PR DESCRIPTION
This pulls request bundles `certbot` in the snap to easily expose enabling https connection to thelounge.