### PR TITLE
Update install hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,7 +3,6 @@
 mkdir -p $SNAP_DATA/home/users
 
 sed $SNAP/defaults/config.js \
-    -e 's/\(prefetch: \)false/\1true/' \
     -e 's|\(theme: "themes/\)example.css"|\1zenburn.css"|' \
     > $SNAP_DATA/home/config.js
 


### PR DESCRIPTION
* Don't reset the configuration item `prefetch`. This brings us closer to upstream's default state when freshly installed.

Fixes: #14 