### PR TITLE
Add setuptools-rust dependency to certbot part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,7 +108,9 @@ apps:
 parts:
   certbot:
     plugin: python
-    python-packages: [certbot]
+    python-packages:
+      - setuptools-rust>=0.11.4
+      - certbot
     build-packages:
       - libffi-dev
       - libcurl4-openssl-dev


### PR DESCRIPTION
* Snapcraft doesn't pull this python package during the pull stage so it isn't
   available in the build stage. Add it as an explicit dependency.